### PR TITLE
Validate array min/max items

### DIFF
--- a/src/parse_schema.rs
+++ b/src/parse_schema.rs
@@ -462,9 +462,18 @@ fn parse_array_type(schema_obj: &Map<String, Value>) -> Result<SchemaState, Pars
 fn parse_array_constraints(
     schema_obj: &Map<String, Value>,
 ) -> Result<(usize, usize), ParseSchemaError> {
-    let min_items = parse_optional_usize_field(schema_obj, "minItems")?.unwrap_or(0);
-    let max_items =
-        parse_optional_usize_field(schema_obj, "maxItems")?.unwrap_or(/* sane default */ 16);
+    let min_items_opt = parse_optional_usize_field(schema_obj, "minItems")?;
+    let max_items_opt = parse_optional_usize_field(schema_obj, "maxItems")?;
+
+    validate_min_max_constraint(
+        min_items_opt,
+        max_items_opt,
+        "minItems cannot be greater than maxItems",
+    )?;
+
+    let min_items = min_items_opt.unwrap_or(0);
+    let max_items = max_items_opt.unwrap_or(/* sane default */ 16);
+
     Ok((min_items, max_items))
 }
 
@@ -1278,6 +1287,23 @@ mod tests {
             assert!(result.is_err());
             if let Err(err) = result {
                 assert!(err.to_string().contains("enum array cannot be empty"));
+            }
+        }
+
+        #[test]
+        fn array_with_invalid_item_constraints() {
+            let schema = json!({
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 5,
+                "maxItems": 2
+            });
+            let result = parse_json_schema(&schema);
+            assert!(result.is_err());
+            if let Err(err) = result {
+                assert!(err
+                    .to_string()
+                    .contains("minItems cannot be greater than maxItems"));
             }
         }
     }


### PR DESCRIPTION
## Summary
- validate minItems/maxItems relationship in array parsing
- test that invalid minItems/maxItems errors out

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68478316f4f4832684cc3fd1a350a5f1

## Summary by Sourcery

Validate array schema’s minItems and maxItems constraints and add a test to error on invalid ranges

Enhancements:
- Ensure minItems is not greater than maxItems during array schema parsing

Tests:
- Add a test case asserting an error when minItems exceeds maxItems in an array schema