### PR TITLE
Fix enum inference variable name

### DIFF
--- a/src/infer.rs
+++ b/src/infer.rs
@@ -959,12 +959,12 @@ mod tests {
                 "foo": "bar",
             }
         ]);
-        let enun_opts = EnumInference {
+        let enum_opts = EnumInference {
             max_unique_ratio: 0.5,
             min_sample_size: 2,
         };
         let options = InferenceOptions {
-            enum_inference: Some(enun_opts),
+            enum_inference: Some(enum_opts),
         };
         let schema = infer_schema(input, &options);
 


### PR DESCRIPTION
## Summary
- fix typo: `enun_opts` -> `enum_opts`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68478522382083269d85f79f096259ef