### PR TITLE
chore: add dependabot config and update ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -9,7 +13,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build
     - name: Run tests


### PR DESCRIPTION
## Summary
- configure Dependabot for Cargo and GitHub Actions
- run CI on pushes and pull requests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e0fcc07c8326b45afb6ce58a7298

## Summary by Sourcery

Configure Dependabot for weekly dependency updates and enhance the CI workflow by targeting the main branch and updating the checkout action.

New Features:
- Add a dependabot.yml to enable weekly updates for Cargo and GitHub Actions dependencies

Enhancements:
- Run the CI pipeline on both pushes and pull requests against the main branch
- Upgrade actions/checkout from v3 to v4