### PR TITLE
disable jemalloc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
+    - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - uses: Swatinem/rust-cache@v2
+      with:
+        fetch-depth: 0
+    - uses: swatinem/rust-cache@7939da402645ba29a2df566723491a2c856e8f8a
+      with:
+        shared-key: drivel-${{ runner.os }}
     - name: Build
       run: cargo build
     - name: Run tests
       run: cargo test
+    - name: Memory usage smoke test
+      run: |
+        /usr/bin/time -f "max_rss_kb=%M" cargo run --quiet -- --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
+      - uses: swatinem/rust-cache@v2
       - name: Install cargo-dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
@@ -108,7 +109,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: swatinem/rust-cache@v2
@@ -163,9 +164,10 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
+      - uses: swatinem/rust-cache@v2
       - name: Install cargo-dist
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
@@ -209,9 +211,10 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
+      - uses: swatinem/rust-cache@v2
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
       # Fetch artifacts from scratch-storage
@@ -249,7 +252,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: "Download GitHub Artifacts"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: swatinem/rust-cache@v2
+          fetch-depth: 0
+      - uses: swatinem/rust-cache@7939da402645ba29a2df566723491a2c856e8f8a
+        with:
+          shared-key: drivel-${{ runner.os }}
       - name: Install cargo-dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
@@ -112,8 +115,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: swatinem/rust-cache@v2
+          fetch-depth: 0
+      - uses: swatinem/rust-cache@7939da402645ba29a2df566723491a2c856e8f8a
         with:
+          shared-key: drivel-${{ runner.os }}
           key: ${{ join(matrix.targets, '-') }}
           cache-provider: ${{ matrix.cache_provider }}
       - name: Install cargo-dist
@@ -167,7 +172,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: swatinem/rust-cache@v2
+          fetch-depth: 0
+      - uses: swatinem/rust-cache@7939da402645ba29a2df566723491a2c856e8f8a
+        with:
+          shared-key: drivel-${{ runner.os }}
       - name: Install cargo-dist
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
@@ -214,7 +222,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: swatinem/rust-cache@v2
+          fetch-depth: 0
+      - uses: swatinem/rust-cache@7939da402645ba29a2df566723491a2c856e8f8a
+        with:
+          shared-key: drivel-${{ runner.os }}
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
       # Fetch artifacts from scratch-storage
@@ -255,6 +266,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,15 +104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "cc"
-version = "1.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
-dependencies = [
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,7 +213,6 @@ dependencies = [
  "chrono",
  "clap",
  "fake",
- "jemallocator",
  "lazy_static",
  "rand",
  "rayon",
@@ -435,26 +425,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -698,12 +668,6 @@ dependencies = [
  "thiserror",
  "yaml-rust2",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/hgrsd/drivel"
 chrono = { version = "0.4.38", default-features = false, features = ["alloc"] }
 clap = { version = "4.5.7", features = ["derive"] }
 fake = { version = "2.9.2", features = ["chrono"] }
-jemallocator = "0.5.4"
 lazy_static = "1.4.0"
 rand = "0.8.5"
 rayon = "1.10.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,6 @@ use clap::{Parser, Subcommand};
 use drivel::{SchemaState, ToJsonSchema};
 use serde_json::Value;
 use serde_yaml2;
-use jemallocator::Jemalloc;
-
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Subcommand, Debug)]
 enum Mode {


### PR DESCRIPTION
## Summary
- update GitHub workflows to actions/checkout@v5
- add cargo caching to CI and release jobs
- remove jemallocator to use the system allocator

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a73dc65fdc832688186132dd9aae08

## Summary by Sourcery

Upgrade GitHub workflows to checkout v5, enable cargo dependency caching, and remove jemallocator to use the system allocator

Enhancements:
- Use actions/checkout@v5 in CI and release workflows
- Cache Rust build dependencies with swatinem/rust-cache@v2
- Remove jemallocator dependency and global allocator directive to revert to the system allocator