### PR TITLE
chore: use checkout v5 in workflows

### DIFF
--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -1,0 +1,20 @@
+name: Checkout
+description: Checkout repository including optional submodules and configurable history
+
+inputs:
+  submodules:
+    description: "Submodules configuration passed to actions/checkout"
+    required: false
+    default: "recursive"
+  fetch-depth:
+    description: "Fetch history depth (0 indicates full history)"
+    required: false
+    default: "0"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v5.0.0
+      with:
+        submodules: ${{ inputs.submodules }}
+        fetch-depth: ${{ inputs["fetch-depth"] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: ./.github/actions/checkout-submodules
+      with:
+        fetch-depth: 0
+        submodules: false
     - name: Build
       run: cargo build
     - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - name: Install cargo-dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
@@ -108,9 +106,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ join(matrix.targets, '-') }}
@@ -163,9 +159,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - name: Install cargo-dist
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
@@ -209,9 +203,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
       # Fetch artifacts from scratch-storage
@@ -249,9 +241,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- share submodule checkout config as composite action
- use shared checkout in release workflow
- fetch full git history in CI checkout
- centralize CI checkout via composite action
- pin checkout action to v5.0.0 and allow configurable history/submodules

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e0c6f2b4832691f2a68581fd1f51

## Summary by Sourcery

Centralize and standardize Git checkout across workflows by introducing a composite checkout action pinned to actions/checkout@v5.0.0 with configurable history depth and submodule support, and update existing release and CI workflows to use this new action.

Enhancements:
- Create a composite action at .github/actions/checkout-submodules to encapsulate actions/checkout@v5.0.0 with inputs for submodules and fetch-depth
- Pin the checkout action to version v5.0.0 and default to full history (fetch-depth: 0) with recursive submodules
- Replace all direct uses of actions/checkout@v3 and v4 in release.yml and ci.yml with the new composite checkout action