### PR TITLE
chore: use checkout v5 in workflows

### DIFF
--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Fetch history depth (0 indicates full history)"
     required: false
     default: "0"
+  ref:
+    description: "Branch, tag, or commit SHA to checkout"
+    required: false
+    default: ""
   persist-credentials:
     description: "Whether to persist the authentication credentials configured by checkout"
     required: false
@@ -31,8 +35,9 @@ runs:
       with:
         submodules: ${{ inputs.submodules }}
         fetch-depth: ${{ inputs["fetch-depth"] }}
-        persist-credentials: ${{ inputs["persist-credentials"] }}
-        lfs: ${{ inputs.lfs }}
+        ref: ${{ inputs.ref }}
+        persist-credentials: ${{ fromJSON(inputs["persist-credentials"]) }}
+        lfs: ${{ fromJSON(inputs.lfs) }}
         ssh-key: ${{ inputs["ssh-key"] }}
 
 outputs:

--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -1,0 +1,41 @@
+name: Checkout
+description: Checkout repository including optional submodules and configurable history
+
+inputs:
+  submodules:
+    description: "Submodules configuration passed to actions/checkout"
+    required: false
+    default: "recursive"
+  fetch-depth:
+    description: "Fetch history depth (0 indicates full history)"
+    required: false
+    default: "0"
+  persist-credentials:
+    description: "Whether to persist the authentication credentials configured by checkout"
+    required: false
+    default: "true"
+  lfs:
+    description: "Download Git-LFS files"
+    required: false
+    default: "false"
+  ssh-key:
+    description: "SSH key for cloning private repositories or submodules"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - id: checkout
+      uses: actions/checkout@v5.0.0
+      with:
+        submodules: ${{ inputs.submodules }}
+        fetch-depth: ${{ inputs["fetch-depth"] }}
+        persist-credentials: ${{ inputs["persist-credentials"] }}
+        lfs: ${{ inputs.lfs }}
+        ssh-key: ${{ inputs["ssh-key"] }}
+
+outputs:
+  sha:
+    description: "Checked-out commit SHA"
+    value: ${{ steps.checkout.outputs.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,13 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - id: checkout
+      uses: ./.github/actions/checkout-submodules
+      with:
+        fetch-depth: 0
+        submodules: false
+    - name: Print commit SHA
+      run: echo "Checked out ${{ steps.checkout.outputs.sha }}"
     - name: Build
       run: cargo build
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: false
+        ref: ${{ github.sha }}
     - name: Print commit SHA
       run: echo "Checked out ${{ steps.checkout.outputs.sha }}"
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - name: Install cargo-dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
@@ -108,9 +106,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ join(matrix.targets, '-') }}
@@ -163,9 +159,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - name: Install cargo-dist
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
@@ -209,9 +203,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
       # Fetch artifacts from scratch-storage
@@ -249,9 +241,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/checkout-submodules
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: ./.github/actions/checkout-submodules
+        with:
+          fetch-depth: 1
       - name: Install cargo-dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
@@ -107,6 +109,8 @@ jobs:
         run: |
           git config --global core.longpaths true
       - uses: ./.github/actions/checkout-submodules
+        with:
+          fetch-depth: 1
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ join(matrix.targets, '-') }}
@@ -160,6 +164,8 @@ jobs:
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
       - uses: ./.github/actions/checkout-submodules
+        with:
+          fetch-depth: 1
       - name: Install cargo-dist
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
@@ -204,6 +210,8 @@ jobs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
       - uses: ./.github/actions/checkout-submodules
+        with:
+          fetch-depth: 1
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.16.0/cargo-dist-installer.sh | sh"
       # Fetch artifacts from scratch-storage
@@ -242,6 +250,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: ./.github/actions/checkout-submodules
+        with:
+          fetch-depth: 1
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- share submodule checkout config as composite action
- use shared checkout in release workflow
- fetch full git history in CI checkout
- centralize CI checkout via composite action
- pin checkout action to v5.0.0 and allow configurable history/submodules
- expose additional checkout inputs and SHA output
- show commit SHA in CI workflow

## Testing
- `cargo test`
- `cargo test --target x86_64-pc-windows-gnu --no-run` *(fails: C compiler cannot create executables)*
- `cargo test --target x86_64-apple-darwin --no-run` *(fails: C compiler cannot create executables)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e0c6f2b4832691f2a68581fd1f51

## Summary by Sourcery

Introduce a reusable composite action for repository checkout using actions/checkout v5 and update all workflows to centralize checkout logic with configurable history depth, submodules, and expose the commit SHA.

New Features:
- Add a composite GitHub action for checkout that supports configurable submodules, fetch-depth, credentials persistence, LFS, SSH key, and outputs the checked commit SHA

Enhancements:
- Replace all actions/checkout steps in release and CI workflows with the new composite action
- Pin the underlying actions/checkout to v5.0.0 and enable full history fetch by default

CI:
- Print the checked commit SHA in the CI workflow